### PR TITLE
Store events to send out on connection

### DIFF
--- a/pkg/server/event.go
+++ b/pkg/server/event.go
@@ -3,7 +3,12 @@ package server
 import (
 	"bytes"
 	"fmt"
+	"sync"
 )
+
+type Eventer interface {
+	ToEvent() Event
+}
 
 // Event represents a server sent event(SSE)
 type Event struct {
@@ -28,4 +33,33 @@ func (e Event) ToBytes() []byte {
 	}
 	buf.WriteString(fmt.Sprintf("data: %s\n", e.data))
 	return buf.Bytes()
+}
+
+// uniqueEventHolder will be used to store unique events on a per context
+// basis.
+type uniqueEventHolder struct {
+	m      sync.RWMutex
+	events map[string]Event
+}
+
+func newUniqueEventHolder() *uniqueEventHolder {
+	return &uniqueEventHolder{events: make(map[string]Event, 0)}
+}
+
+func (h *uniqueEventHolder) AddEvent(e Event) {
+	h.m.Lock()
+	defer h.m.Unlock()
+
+	h.events[e.event] = e
+}
+
+func (h *uniqueEventHolder) Events() []Event {
+	h.m.RLock()
+	defer h.m.RUnlock()
+
+	events := make([]Event, len(h.events))
+	for _, e := range h.events {
+		events = append(events, e)
+	}
+	return events
 }

--- a/pkg/server/event_store.go
+++ b/pkg/server/event_store.go
@@ -1,0 +1,27 @@
+package server
+
+import "sync"
+
+var rwmEventStore sync.RWMutex
+var eventStore = make(map[string]*uniqueEventHolder, 0)
+
+func addToEventStore(context string, e Event) {
+	rwmEventStore.Lock()
+	defer rwmEventStore.Unlock()
+
+	if _, ok := eventStore[context]; !ok {
+		eventStore[context] = newUniqueEventHolder()
+	}
+	eventStore[context].AddEvent(e)
+}
+
+func getLatestEvents() []Event {
+	rwmEventStore.RLock()
+	defer rwmEventStore.RUnlock()
+
+	events := make([]Event, 0)
+	for _, h := range eventStore {
+		events = append(events, h.Events()...)
+	}
+	return events
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -73,7 +73,7 @@ func (s *StatusServer) sendPods(context string) {
 		Context: context,
 		Pods:    pods,
 	}
-	s.sendEvent(ps.ToEvent())
+	s.updateStoreAndSend(context, ps)
 }
 
 func (s *StatusServer) sendJobs(context string) {
@@ -86,7 +86,13 @@ func (s *StatusServer) sendJobs(context string) {
 		Context: context,
 		Jobs:    jobs,
 	}
-	s.sendEvent(js.ToEvent())
+	s.updateStoreAndSend(context, js)
+}
+
+func (s *StatusServer) updateStoreAndSend(context string, ei Eventer) {
+	e := ei.ToEvent()
+	addToEventStore(context, e)
+	s.sendEvent(e)
 }
 
 func (s *StatusServer) sendEvent(e Event) {

--- a/pkg/server/sse_broker.go
+++ b/pkg/server/sse_broker.go
@@ -83,6 +83,12 @@ func (b *Broker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
+	// Send latest events first so page isn't waiting until next update
+	for _, e := range getLatestEvents() {
+		fmt.Fprintf(w, "%s\n\n", e.ToBytes())
+		f.Flush()
+	}
+
 	for {
 		msg, ok := <-client
 		if !ok {


### PR DESCRIPTION
Resolves #1 . 

Still doesn't fix the very very first data load before we have made k8s calls, but after that we now get the most recent data for each context as soon as we load the page.